### PR TITLE
Fix base requirements for gnns

### DIFF
--- a/reactive-flows/cnf-combustion/gnns/requirements.txt
+++ b/reactive-flows/cnf-combustion/gnns/requirements.txt
@@ -58,7 +58,7 @@ oauthlib==3.2.2
 packaging==24.2
 pandas==2.2.3
 pillow==11.0.0
-pip==22.0.2
+pip==24.3.1
 platformdirs==4.3.6
 plotly==5.24.1
 propcache==0.2.1
@@ -81,7 +81,7 @@ requests-oauthlib==2.0.0
 rsa==4.9
 scikit-learn==1.6.0
 scipy==1.14.1
-setuptools==59.6.0
+setuptools==75.1.0
 six==1.17.0
 sympy==1.13.1
 tenacity==9.0.0
@@ -103,7 +103,7 @@ tzdata==2024.2
 urllib3==2.2.3
 virtualenv==20.28.0
 Werkzeug==3.1.3
-wheel==0.37.1
+wheel==0.44.0
 yacs==0.1.8
 yarl==1.18.3
 zipp==3.21.0


### PR DESCRIPTION
Fix the missed updated lib in the `requirements.txt` file of the `reactive-flows/cnf-combustion/gnns` model.